### PR TITLE
dict.get() instead of 'in'

### DIFF
--- a/movie_plist/data/fetch_data.py
+++ b/movie_plist/data/fetch_data.py
@@ -88,10 +88,10 @@ class FetchImdbData:
 
 # helper func
 def add_synopsis(title, synopsis):
-    d_movie = MOVIE_UNSEEN
+    d_movie = MOVIE_SEEN
 
-    if title in MOVIE_SEEN:
-        d_movie = MOVIE_SEEN
+    if MOVIE_UNSEEN.get(title):
+        d_movie = MOVIE_UNSEEN
 
     movie_info = list(d_movie[title])
     movie_info.insert(1, synopsis)


### PR DESCRIPTION
unseen probably is smaller and contain title
if not, no big deal. timeit test 1000
and and wily increases some points

dict has title:
in:       0.00019824199989670888 secs (1000 loops)
dict.get: 0.00015254599929903634 secs (1000 loops)

dict has not title:
in:       0.00014125400048214942 secs (1000 loops)
dict.get: 0.00015851700118219014 secs (1000 loops)

close #77